### PR TITLE
remove non-ssl url

### DIFF
--- a/NamuFix.user.js
+++ b/NamuFix.user.js
@@ -3,7 +3,6 @@
 // @namespace   http://litehell.info/
 // @description 나무위키 등 더시드 사용 위키의 편집 인터페이스 등을 개선합니다.
 // @include     https://namu.wiki/*
-// @include     https://no-ssl.namu.wiki/*
 // @include     https://alphawiki.org/*
 // @include     https://www.alphawiki.org/*
 // @include     https://theseed.io/*


### PR DESCRIPTION
Namuwiki stopped supporting non-ssl version url