### PR TITLE
특정 유저스크립트 매니저 사용시 IP 조회불가 현상 수정

### DIFF
--- a/NamuFix.user.js
+++ b/NamuFix.user.js
@@ -2647,7 +2647,7 @@ if (location.host === 'board.namu.wiki') {
             message.nfHeadspan.appendChild(span);
             span.innerHTML = "[(IP 확인중: IP정보 조회중)]";
             // get ip info
-            getIpInfo(message.author.name, async function (resObj) {
+            getIpInfo(message.author.name, SET.ipInfoDefaultOrg, async function (resObj) {
                if (resObj !== null) {
                   let country = resObj.country;
                   let countryName = korCountryNames[country.toUpperCase()] || country;
@@ -2865,7 +2865,7 @@ if (location.host === 'board.namu.wiki') {
             var ipInfo = document.createElement("p");
             ipInfo.innerHTML = '<div style="border: 1px black solid; padding: 2px;">IP 관련 정보를 조회중입니다. 잠시만 기다려주세요.</div>'
             insertBeforeTable(ipInfo);
-            getIpInfo(ip, function (resObj) {
+            getIpInfo(ip, SET.ipInfoDefaultOrg, function (resObj) {
                var country = resObj.country;
                var countryName = korCountryNames[country.toUpperCase()] || country.toUpperCase();
                var isp = resObj.org;

--- a/src/whoisIpUtils.js
+++ b/src/whoisIpUtils.js
@@ -8,7 +8,7 @@ function IsObjectSubsetOf(a, b) {
 
 function whoisIpUtils() {
     let ipDictionary = {};
-    this.getIpInfo = (ip, cb) => {
+    this.getIpInfo = (ip, org, cb) => {
         if (ipDictionary[ip]) return cb(ipDictionary[ip]);
         GM.xmlHttpRequest({
             method: "GET",
@@ -19,7 +19,7 @@ function whoisIpUtils() {
                     if (/^AS[0-9]+ /.test(resObj.org)) {
                         resObj.org = resObj.org.replace(/^AS[0-9]+ /, '');
                     }
-                    if (SET.ipInfoDefaultOrg != 'ipinfo.io') {
+                    if (org != 'ipinfo.io') {
                         getIpWhois(ip, function (whoisRes) {
                             if (!whoisRes.success || whoisRes.raw) {
                                 ipDictionary[ip] = resObj;
@@ -38,11 +38,11 @@ function whoisIpUtils() {
                                     infoName: 'netinfo',
                                     name: 'orgName'
                                 }, v))[0] || {value: null}).value;
-                            if (SET.ipInfoDefaultOrg === 'KISAuser' && koreanUser) {
+                            if (org === 'KISAuser' && koreanUser) {
                                 resObj.org = koreanUser;
-                            } else if (SET.ipInfoDefaultOrg === 'KISAISP' && koreanISP) {
+                            } else if (org === 'KISAISP' && koreanISP) {
                                 resObj.org = koreanISP;
-                            } else if (SET.ipInfoDefaultOrg === 'KISAuserOrISP' && (koreanUser || koreanISP)) {
+                            } else if (org === 'KISAuserOrISP' && (koreanUser || koreanISP)) {
                                 resObj.org = koreanUser ? koreanUser : koreanISP;
                             }
                             ipDictionary[ip] = resObj;


### PR DESCRIPTION
VIolentmonkey 유저스크립트 매니저 사용시 require된 스크립트에서 본체 스크립트 스코프에 접근하지 못해 SET 변수를 읽을 수 없는 현상이 있습니다. 이를 수정하여 본체 스크립트에서 설정값을 함수에 넘겨주도록 합니다.